### PR TITLE
0710 jlu join channel msg

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -11,6 +11,21 @@ Channel::Channel(std::string name) :
 	creationTime = getCurrentTime();
 }
 
+int	Channel::getOpCount()
+{
+	int count = 0;
+	for (std::vector<User>::iterator it = channel_users.begin(); it != channel_users.end(); it++)
+	{
+		if (it->operator_permissions)
+			count++;
+	}
+	return count;
+}
+
+int		Channel::getTotalCount()
+{
+	return channel_users.size();
+}
 
 void	Channel::setChannelTopic(std::string new_topic, Client &client)
 {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,6 +6,7 @@ Channel::Channel(std::string name) :
 		name					(name),
 		user_limit				(-1),
 		invite_only				(false),//TODO. Confirm this is default setting
+		keyRequired				(false),
 		topic_requires_operator	(true)	//TODO. Confirm this is default setting
 {
 	creationTime = getCurrentTime();

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -28,6 +28,7 @@ class Channel
 		int				user_limit;
 		int 			OpCount;
 		int				totalCount;
+		bool			keyRequired; // maybe we don't need this?
 		bool			invite_only;
 		bool			topic_requires_operator;
 

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -26,6 +26,8 @@ class Channel
 		std::string		creationTime;
 
 		int				user_limit;
+		int 			OpCount;
+		int				totalCount;
 		bool			invite_only;
 		bool			topic_requires_operator;
 
@@ -53,6 +55,8 @@ class Channel
 		std::string			getChannelTime(){return creationTime;}
 
 		int					getUserLimit(){return user_limit;}
+		int					getOpCount();
+		int					getTotalCount();
 		bool				getInviteOnly(){return invite_only;}
 		bool				getTopicRequiresOperator(){return topic_requires_operator;}
 		std::vector<User>	getChannelUsers(){return channel_users;}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -191,7 +191,7 @@ std::string getCurrentTime()
 	time_t now = time(0);
 	char timeStr[100];
     struct tm *localTime = localtime(&now);
-    strftime(timeStr, sizeof(timeStr), "%Y-%m-%d %H:%M:%S", localTime);
+    strftime(timeStr, sizeof(timeStr), "%A, %Y-%m-%d %H:%M:%S", localTime);
     return std::string(timeStr);
 }
 

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -81,6 +81,7 @@ class Server {
 		int		privmsgCommand(Msg msg, int clientSocket, Client &client);
 		void	channelMessage(Msg msg, int clientSocket, Client &client);		
 		void	directMessage(Msg msg, int clientSocket, Client &client);
+		void   joinChannelMessage(std::string channelName, Client &client);
 
 		int		modeCommand(Msg msg, int clientSocket, Client &client);
 

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -62,7 +62,6 @@ class Server {
 		int		channelExists(std::string channel);
 		int		removeUser(std::string user, std::string channel, std::string message, int partOrKick);
 		int		clientStatus(Msg msg, Client &client);
-		int 	checkErrorInMode(Msg msg, int clientSocket);
 		Channel* getChannel(std::string channelName);
 
 		int     topicCommand(Msg msg, int clientSocket, Client &client);

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -88,17 +88,10 @@ int		Server::joinCommand(Msg msg, int clientSocket, Client &client)
 	}
 	i = getChannelIndex(msg.parameters[0], this->channel_names);
 	// need to make sure that we don't send this message to the channels if the user didn't join
-	std::string message = ":ircserver PRIVMSG " + msg.parameters[0] + " :" + client.getNickname() + " [~" + client.getUsername() + "@" + client.getHostIP() + "] has joined " + msg.parameters[0] + "\r\n";	
+	// std::string message = ":ircserver PRIVMSG " + msg.parameters[0] + " :" + client.getNickname() + " [~" + client.getUsername() + "@" + client.getHostIP() + "] has joined " + msg.parameters[0] + "\r\n";
+	std::string message = ":" + client.getNickname() + "!" + "~" + client.getUsername() + "@" + client.getHostIP() + " JOIN " + msg.parameters[0] + "\r\n";
 	broadcastToChannel(this->channel_names[i], message);//Send sender Fd??
 	joinChannelMessage(msg.parameters[0], client);
-	// int OpCount = this->channel_names[i].getOpCount();
-	// int totalCount = this->channel_names[i].getTotalCount();
-	// std::string joinMsg = ":ircserver PRIVMSG " + msg.parameters[0] + " :Total of " + std::to_string(totalCount) + " nicks [" + std::to_string(OpCount) + " ops, " + std::to_string(totalCount - OpCount) + " normal]\r\n";
-	// send(client.getSocket(), joinMsg.c_str(), joinMsg.size(), 0);
-	// std::string channelCreated;
-	// channelCreated = ":ircserver PRIVMSG " + msg.parameters[0] + " :Channel " + msg.parameters[0] + " create " + getCurrentTime() + "\r\n";
-	// send(client.getSocket(), channelCreated.c_str(), channelCreated.size(), 0);
-
 	//WELCOME_MSG - Send message to client who connected to channel
 
 	/*

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -55,7 +55,21 @@ int		Server::joinChannel(Msg msg, int clientSocket, Client &client, int index)
 
 	return (0);
 }
+//maybe we can use privmsg to send this message to the client in the channel
 
+void Server::joinChannelMessage(std::string channelName, Client &client)
+{
+	int i = getChannelIndex(channelName, this->channel_names);
+	int OpCount = this->channel_names[i].getOpCount();
+	int totalCount = this->channel_names[i].getTotalCount();
+	std::string joinMsg;
+	joinMsg = ":ircserver PRIVMSG " + channelName + " :Total of " + std::to_string(totalCount) + " nicks [" + std::to_string(OpCount) + " ops, " + std::to_string(totalCount - OpCount) + " normal]\r\n";
+	send(client.getSocket(), joinMsg.c_str(), joinMsg.size(), 0);
+	
+	std::string channelCreated;
+	channelCreated = ":ircserver PRIVMSG " + channelName + " :Channel " + channelName + " create " + this->channel_names[i].getChannelTime() + "\r\n";
+	send(client.getSocket(), channelCreated.c_str(), channelCreated.size(), 0);
+}
 int		Server::joinCommand(Msg msg, int clientSocket, Client &client)
 {
 	int i = getChannelIndex(msg.parameters[0], this->channel_names);
@@ -73,10 +87,17 @@ int		Server::joinCommand(Msg msg, int clientSocket, Client &client)
 		
 	}
 	i = getChannelIndex(msg.parameters[0], this->channel_names);
-
 	// need to make sure that we don't send this message to the channels if the user didn't join
-	std::string message = ":ircserver PRIVMSG " + msg.parameters[0] + " :" + client.getNickname() + " has joined " + msg.parameters[0] + "\r\n";	
+	std::string message = ":ircserver PRIVMSG " + msg.parameters[0] + " :" + client.getNickname() + " [~" + client.getUsername() + "@" + client.getHostIP() + "] has joined " + msg.parameters[0] + "\r\n";	
 	broadcastToChannel(this->channel_names[i], message);//Send sender Fd??
+	joinChannelMessage(msg.parameters[0], client);
+	// int OpCount = this->channel_names[i].getOpCount();
+	// int totalCount = this->channel_names[i].getTotalCount();
+	// std::string joinMsg = ":ircserver PRIVMSG " + msg.parameters[0] + " :Total of " + std::to_string(totalCount) + " nicks [" + std::to_string(OpCount) + " ops, " + std::to_string(totalCount - OpCount) + " normal]\r\n";
+	// send(client.getSocket(), joinMsg.c_str(), joinMsg.size(), 0);
+	// std::string channelCreated;
+	// channelCreated = ":ircserver PRIVMSG " + msg.parameters[0] + " :Channel " + msg.parameters[0] + " create " + getCurrentTime() + "\r\n";
+	// send(client.getSocket(), channelCreated.c_str(), channelCreated.size(), 0);
 
 	//WELCOME_MSG - Send message to client who connected to channel
 

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -1,22 +1,6 @@
 
 #include "Server.hpp"
 
-int		Server::checkErrorInMode(Msg msg, int clientSocket)
-{
-	if (msg.parameters.size() <= 1)
-	{
-		return (1);
-	}
-	else if (msg.parameters[0][0] != '#')
-	{
-		return (1);
-	}
-	else if (msg.parameters[1].empty())
-	{
-		return (1);
-	}
-	return (0);
-}
 
 int 	Server::clientStatus(Msg msg, Client &client)
 {
@@ -49,14 +33,13 @@ Channel* Server::getChannel(std::string channelName)
 
 int		Server::modeCommand(Msg msg, int clientSocket, Client &client)
 {
-	if (checkErrorInMode(msg, clientSocket) == 1)
-		return (1);
 	if (clientStatus(msg, client) == 0)
 	{
-		std::string errMsg = ":" + client.getNickname() + " MODE " + msg.parameters[1] + " :You're not a channel operator\r\n";
+		std::string errMsg = ":ircserver 482 " + client.getNickname() + " " + msg.parameters[0] + " :You're not a channel operator\r\n";
 		send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
 		return (1);
 	}
+	printMsg(msg); //debug
 	//find the current channel to apply the mode + flag
 	Channel* tarChannel = getChannel(msg.parameters[0]);
 	if (tarChannel == nullptr)
@@ -67,46 +50,113 @@ int		Server::modeCommand(Msg msg, int clientSocket, Client &client)
 	}
 	//parse the command
 	std::cout << "Channel name: " << tarChannel->name << std::endl; //debug
-	if (msg.parameters[1] == "+i" || msg.parameters[1] == "-i")
+	if (msg.parameters[1].empty())
+	{
+		std::string u_modeIs = ":ircserver 221 " + client.getNickname() + " User Modes=i,t,k,o,l" + "\r\n";
+    	send(client.getSocket(), u_modeIs.c_str(), u_modeIs.size(), 0);
+	}
+	else if (msg.parameters[1] == "+i" || msg.parameters[1] == "-i")
 	{
 		std::cout << "i" << std::endl; //debug
 		tarChannel->invite_only = (msg.parameters[1] == "+i") ? true : false;
+		std::cout << "+i/-i" << std::endl; //debug
+		std::string inviteMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " " + msg.parameters[1] + "\r\n";
+		broadcastToChannel(*tarChannel, inviteMsg);
 	}
 	else if (msg.parameters[1] == "+t" || msg.parameters[1] == "-t")
 	{
 		tarChannel->topic_requires_operator = (msg.parameters[1] == "+t") ? true : false;
+		std::cout << "+t/-t" << std::endl; //debug
+		std::string topicMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " " + msg.parameters[1] + "\r\n";
+		broadcastToChannel(*tarChannel, topicMsg);
 	}
 	else if (msg.parameters[1] == "+k" || msg.parameters[1] == "-k")
 	{
-		std::cout << "k" << std::endl; //debug
-		std::cout << "Setting Channel Key: " << msg.parameters[2] << std::endl; //debug
-		tarChannel->channel_key = (msg.parameters[1] == "+k") ? msg.parameters[2] : "";
+		std::cout << msg.parameters[1] << std::endl; //debug
+		if (msg.parameters[1] == "+k" && msg.parameters[2].empty()) //check if key is empty or not. not sure if this is the right error code to return
+		{
+			std::cout << "Key is empty" << std::endl; //debug
+			std::string errMsg = ":ircserver 525" + client.getNickname() + " " + msg.parameters[0] + " :Key is not well-formed\r\n";
+			send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
+			return (1);
+		}
+		else if (msg.parameters[1] == "+k") {
+			std::cout << "Setting Channel Key: " << msg.parameters[2] << std::endl; //debug
+			tarChannel->channel_key = msg.parameters[2];
+			tarChannel->keyRequired = true;
+			std::string keyMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " +k " + msg.parameters[2] + "\r\n";
+			broadcastToChannel(*tarChannel, keyMsg);
+		}
+		else if (msg.parameters[1] == "-k")
+		{
+			std::cout << "Removing Channel Key" << std::endl; //debug
+			tarChannel->channel_key = "";
+			tarChannel->keyRequired = false;
+			std::string keyMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " -k *" + "\r\n";
+			broadcastToChannel(*tarChannel, keyMsg);
+		}
 	}
 	else if (msg.parameters[1] == "+o" || msg.parameters[1] == "-o")
 	{			
 		std::cout << "o" << std::endl; //debug
 		//TODO: Give/take channel operator privilege
+		// need to check if names is given before
+		if (msg.parameters[2].empty())
+		{
+			std::string errMsg = ":ircserver 461 " + client.getNickname() + " MODE :Not enough parameters\r\n";
+			send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
+			return (1);
+		}
+		bool nickExists = false;
 		for (int i = 0; i < tarChannel->channel_users.size(); i++)
 		{
 			if (tarChannel->channel_users[i].nickname == msg.parameters[2])
 			{
+				// need to make sure it is not the client itself
+				nickExists = true;
 				std::cout << "found: " << tarChannel->channel_users[i].nickname << std::endl; //debug
 				std::cout << tarChannel->channel_users[i].operator_permissions << std::endl; //debug
 				tarChannel->channel_users[i].operator_permissions = (msg.parameters[1] == "+o") ? true : false;
 				std::cout << tarChannel->channel_users[i].operator_permissions << std::endl; //debug
+				std::string chMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " " + msg.parameters[1] + " " + msg.parameters[2] + "\r\n";
+				broadcastToChannel(*tarChannel, chMsg);
 				break;
 			}
+		}
+		if (nickExists == false)
+		{
+			std::string errMsg = ":ircserver 441 " + client.getNickname() + " " + msg.parameters[2] + " " + msg.parameters[0] + " :They aren't on that channel\r\n";
+			send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
+			return (1);
 		}
 	}
 	else if (msg.parameters[1] == "+l" || msg.parameters[1] == "-l")
 	{
 		std::cout << "l" << std::endl; //debug
 		tarChannel->user_limit = (msg.parameters[1] == "+l") ? std::stoi(msg.parameters[2]) : 0;
+		std::string limitMsg;
+		if (msg.parameters[1] == "+l")
+		{
+			if (msg.parameters[2].empty())
+			{
+				std::string errMsg = ":ircserver 461 " + client.getNickname() + " MODE :Not enough parameters\r\n";
+				send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
+				return (1);
+			}
+			else 
+				limitMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " " + msg.parameters[1] + " " + msg.parameters[2] + "\r\n";
+		}
+		else
+		{
+			limitMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " " + msg.parameters[1] + "\r\n";
+		}
+		broadcastToChannel(*tarChannel, limitMsg);
 	}
 	else
 	{
-		std::string errMsg = ":" + client.getNickname() + " MODE " + msg.parameters[0] + " :Unknown MODE flag\r\n";
+		std::string errMsg = ":ircserver 472" + client.getNickname() + " " + msg.parameters[1] + " :is unknown mode char to me\r\n";
 		send(clientSocket, errMsg.c_str(), errMsg.size(), 0);
+		return (1);
 	}
 	return (0);
 }

--- a/src/part.cpp
+++ b/src/part.cpp
@@ -48,7 +48,7 @@ int		Server::partCommand(Msg msg, int clientSocket, Client &client)
 				if (userExists(client.getNickname(), channels[i]))
 				{
 					int j = getChannelIndex(channels[i], channel_names);
-					std::string fullPrefix = client.getNickname() + "!" + client.getUsername() + "@" + client.getHostIP();
+					std::string fullPrefix = client.getNickname() + "!" + "~" + client.getUsername() + "@" + client.getHostIP();
 					std::string part;
 					if (!msg.trailing_msg.empty())
 						part = ":" + fullPrefix + " PART " + channel.name + " :" + msg.trailing_msg + "\r\n";


### PR DESCRIPTION
Added corresponding error codes and message that is broadcasted to the channels when a client makes a change with /mode 

+l is still connecting to the next parameters for some reason. I also realized a bunch of other letters will cause the same thing such as a, b, c, d, and etc. 
