### PR TITLE
informing other clients when a client quit/disconnect

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -101,6 +101,7 @@ void Server::acceptClient()
 
 void Server::removeFromAll(int i)
 {
+	std::cout << "removeFromAll" << std::endl;
 	for (auto &client : clients) // remove user from all channels
 	{
 		if (client.getSocket() == pollfds[i].fd) 
@@ -111,7 +112,10 @@ void Server::removeFromAll(int i)
 				{
 					if (client.getNickname() == user.nickname)
 					{
+						int j = getChannelIndex(channel.name, channel_names);
 						std::string message = "REMOVE " + user.nickname + " from " + channel.name;
+						std::string quitMessage = ":" + user.nickname + " QUIT " + ":Client has quit\r\n";
+						broadcastToChannel(this->channel_names[j], quitMessage);
 						removeUser(user.nickname, channel.name, message, 2);
 						client.leaveChannel(channel.name);
 					}
@@ -154,12 +158,13 @@ void Server::serverLoop()
 				int bytesRead = recv(pollfds[i].fd, buffer, sizeof(buffer), 0);
 				if (bytesRead <= 0) 
 				{
-					if (bytesRead == 0) 
+					if (bytesRead == 0) {
+						removeFromAll(i);
 						std::cout << "Client disconnected, socket " << pollfds[i].fd << std::endl;
+					}
 					else 
 						std::cerr << "Error reading from socket " << pollfds[i].fd << " " << strerror(errno) << std::endl;
 
-					removeFromAll(i);
 
 					close(pollfds[i].fd);
 					pollfds.erase(pollfds.begin() + i);

--- a/src/kick.cpp
+++ b/src/kick.cpp
@@ -10,12 +10,12 @@ int		Server::removeUser(std::string user, std::string channel, std::string messa
 		{
 			int socket = getClientSocket(channel_names[i].channel_users[j].nickname);
 			channel_names[i].channel_users.erase(channel_names[i].channel_users.begin() + j);
-			if (partOrKick == 1)
+			if (partOrKick == 1) //kick
 			{
 				std::string notice = ":ircserv NOTICE " + user + " :" + message + " " + channel + " \r\n";
 				send(socket, notice.c_str(), notice.size(), 0);
 			} 
-			else if (partOrKick == 0) 
+			else if (partOrKick == 0) //part
 			{
 				send(socket, message.c_str(), message.size(), 0);
 				std::cout << "Debug: message = " << message << std::endl;


### PR DESCRIPTION

Good:
When a user disconnect or quit, the client sends a command to the server, then the server informs all the users that share a channel with the client that quit by sending a quitMessage. 

Questions/issues:
one user will receive the info of the client leaving in their window 1. 
if client a and b shares four channels together and priv msg query, when client b quits, in the query, client a will receive FOUR times of the quitting messages. 