### PR TITLE
1301 tparratt kick invite fixes

### DIFF
--- a/src/connectionMessages.cpp
+++ b/src/connectionMessages.cpp
@@ -14,7 +14,7 @@ int		Server::passwordCommand(Msg msg, int clientSocket, Client &client)
 	return (0);
 }
 
-int Server::nickClash(const std::string& nickname, int socket)
+int		Server::nickClash(const std::string& nickname, int socket)
 {
     // Check if any other client has the same nickname
     for (auto &client : clients) 
@@ -31,19 +31,13 @@ int Server::nickClash(const std::string& nickname, int socket)
 int		Server::nicknameCommand(Msg msg, int clientSocket, Client &client)
 {
 	if (!client.getWelcomeSent() && client.getNickname().empty())
-	{
 		client.setNickname(msg.parameters[0]);
-	}
-	else if (msg.parameters[0].empty()) //ERR_NONICKNAMEGIVEN (431)
+	else if (msg.parameters[0].empty())
 	{
 		std::string message_431 = ":ircserv 431 " + client.getNickname() + " :No nickname given\r\n";
 		send(clientSocket, message_431.c_str(), message_431.size(), 0);
 	}
-	// else if ()
-	// {
-	// 	//ERR_ERRONEUSNICKNAME (432)
-	// }
-	else if (this->nickClash(msg.parameters[0], clientSocket)) //ERR_NICKNAMEINUSE (433)
+	else if (this->nickClash(msg.parameters[0], clientSocket))
 	{
 		std::string message_433 = ":ircserv 433 " + msg.parameters[0] + " :" + msg.parameters[0] + "\r\n";
 		send(clientSocket, message_433.c_str(), message_433.size(), 0);
@@ -56,7 +50,6 @@ int		Server::nicknameCommand(Msg msg, int clientSocket, Client &client)
 		std::string new_nick = client.getNickname();
 		std::string nick_message = ":" + old_nick + " NICK " + new_nick + "\r\n";
 		send(clientSocket, nick_message.c_str(), nick_message.size(), 0);
-
 		//change channel users name to new nick
 		for (auto &channel : channel_names) 
 		{

--- a/src/joinChecks.cpp
+++ b/src/joinChecks.cpp
@@ -76,33 +76,7 @@ int		Server::channelJoinChecks(Channel channel, Msg msg, int clientSocket, Clien
 		return (1) ;
 	}
 
-	if (channel.isChannelInviteOnly() == true)
-	{
-		/*
-			a. If Invited
-				-> OK
-
-			b. If not Invited
-				-> Send message
-		*/
-
-		for (auto &it : channel.invited)
-		{
-			if (it == client.getNickname())
-			{
-				return (0);				//User was Invited
-			}
-		}
-
-		message  = ":ircserv 473 " + client.getNickname() + " " + msg.parameters[0] + " :Cannot join channel (+i) - you must be invited\r\n";
-		send(clientSocket, message.c_str(), message.size(), 0);
-
-		//example << JOIN #BANNNANAss
-		//example >> :lithium.libera.chat 473 gravity123 #BANNNANAss :Cannot join channel (+i) - you must be invited
-		return (1);						//User was NOT Invited
-	}
-	
- 	if (channel.doesChannelHavePassword() == true)
+	if (channel.doesChannelHavePassword() == true)
 	{
 		if (msg.parameters.size() <= 1)						 //No password parameter passed.
 		{
@@ -138,5 +112,32 @@ int		Server::channelJoinChecks(Channel channel, Msg msg, int clientSocket, Clien
 			return (1);
 		}
 	}
+
+	if (channel.isChannelInviteOnly() == true)
+	{
+		/*
+			a. If Invited
+				-> OK
+
+			b. If not Invited
+				-> Send message
+		*/
+
+		for (auto &it : channel.invited)
+		{
+			if (it == client.getNickname())
+			{
+				return (0);				//User was Invited
+			}
+		}
+
+		message  = ":ircserv 473 " + client.getNickname() + " " + msg.parameters[0] + " :Cannot join channel (+i) - you must be invited\r\n";
+		send(clientSocket, message.c_str(), message.size(), 0);
+
+		//example << JOIN #BANNNANAss
+		//example >> :lithium.libera.chat 473 gravity123 #BANNNANAss :Cannot join channel (+i) - you must be invited
+		return (1);						//User was NOT Invited
+	}
+
 	return (0);
 }

--- a/src/kick.cpp
+++ b/src/kick.cpp
@@ -51,6 +51,11 @@ int		Server::kickCommand(Msg msg, int clientSocket, Client &client)
 									broadcastToChannel(channel_names[i], kick);
 									removeUser(msg.parameters[1], msg.parameters[0], "You have been kicked from", 1);
 									client.leaveChannel(msg.parameters[0]);
+									for (int i = 0; i < sizeof(channel.invited); i++)
+									{
+										if (msg.parameters[1] == channel.invited[i])
+											channel.invited.erase(channel.invited.begin() + i);
+									}
 								}
 								else
 								{

--- a/src/kick.cpp
+++ b/src/kick.cpp
@@ -47,7 +47,7 @@ int		Server::kickCommand(Msg msg, int clientSocket, Client &client)
 								if (userExists(msg.parameters[1], msg.parameters[0]))
 								{
 									int i = getChannelIndex(msg.parameters[0], channel_names);
-									std::string kick = ":" + kicker.nickname + " KICK " + channel.getChannelName() + " " + msg.parameters[1] + "\r\n";
+									std::string kick = ":" + kicker.nickname + " KICK " + channel.getChannelName() + " " + msg.parameters[1] + " " + msg.trailing_msg + "\r\n";
 									broadcastToChannel(channel_names[i], kick);
 									removeUser(msg.parameters[1], msg.parameters[0], "You have been kicked from", 1);
 									client.leaveChannel(msg.parameters[0]);


### PR DESCRIPTION
- Kick reason now shows
- If a user is kicked the users invited status is removed
- If a user is invited to a channel requiring a key, the user cannot enter without entering the key.