### PR TITLE
1601 tparratt testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SRC			=	src/main.cpp \
 				src/privmsg.cpp \
 				src/Server.cpp \
 				src/topic.cpp \
+				src/who.cpp \
 
 OBJ			=	$(SRC:.cpp=.o)
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -7,7 +7,7 @@ Client::Client(int socket, const std::string& password) :
 					_welcomeSent		(false),
 					_socket				(socket)
 {
-	setHostIP();
+	//setHostIP();
 	// setPrefix();
 };
 
@@ -26,9 +26,24 @@ std::string Client::getPassword()
     return(_password);
 }
 
-std::string Client::getHostIP()
+/*std::string Client::getHostIP()
 {
     return(_hostIP);
+}*/
+
+std::string Client::getHost()
+{
+    return(_host);
+}
+
+std::string Client::getRealname()
+{
+    return(_realname);
+}
+
+std::string Client::getHostname()
+{
+    return(_hostname);
 }
 
 std::string Client::getPrefix()
@@ -72,6 +87,21 @@ void        Client::setUsername(std::string str)
     _username = str;
 }
 
+void        Client::setHost(std::string str)
+{
+    _host = str;
+}
+
+void        Client::setHostname(std::string str)
+{
+    _hostname = str;
+}
+
+void        Client::setRealname(std::string str)
+{
+    _realname = str;
+}
+
 void       Client::setPrefix(std::string prefix)
 {
     _prefix = prefix;
@@ -92,7 +122,7 @@ void        Client::setOperatorStatus(bool value)
     _operatorStatus = value;
 }
 
-void Client::setHostIP()
+/*void Client::setHostIP()
 {
     char hostname[NI_MAXHOST];
     if (gethostname(hostname, sizeof(hostname)) != 0)
@@ -127,7 +157,7 @@ void Client::setHostIP()
 
     std::cerr << "Failed to convert address to string" << std::endl;
     freeaddrinfo(res);
-}
+}*/
 
 void        Client::joinChannel(std::string channelName)
 {

--- a/src/Client.hpp
+++ b/src/Client.hpp
@@ -12,7 +12,9 @@ class Client
     private:
         std::string _nickname;
         std::string _username;
-        std::string _hostIP;
+        //std::string _hostIP;
+        std::string _host;
+        std::string _hostname;
         std::string _realname;
         std::string _password;
         std::string _prefix;
@@ -31,18 +33,24 @@ class Client
         std::string getNickname();
         std::string getUsername();
         std::string getPassword();
+        std::string getHost();
+        std::string getHostname();
+        std::string getRealname();
         std::vector<std::string>& getChannelsNames();
         bool        getPasswordChecked();
         bool        getWelcomeSent();
         bool        getOperatorStatus();
         int         getSocket();
-        std::string getHostIP();
+        //std::string getHostIP();
         std::string getPrefix();
 
         void        setNickname(std::string str);
         void        setUsername(std::string str);
         void        setPrefix(std::string str);
-        void        setHostIP();
+        //void        setHostIP();
+        void        setHost(std::string str);
+        void        setRealname(std::string str);
+        void        setHostname(std::string str);
         void        setPasswordChecked(bool value);
         void        setWelcomeSent(bool value);
         void        setOperatorStatus(bool value);

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -59,6 +59,7 @@ class Server {
 		void	topicPrint(std::string channelName, Client &client);
 		void	partCommand(Msg msg, Client &client);
 		void	joinCommand(Msg msg, Client &client);
+		void	whoCommand(Msg msg, Client &client);
 		void    createChannel(Msg msg, Client &client);
 		int		channelJoinChecks(Channel channel, Msg msg, Client &client);
 

--- a/src/connectionMessages.cpp
+++ b/src/connectionMessages.cpp
@@ -47,8 +47,8 @@ int		Server::nicknameCommand(Msg msg, Client &client)
 		std::string old_nick = client.getNickname();
 		client.setNickname(msg.parameters[0]);
 		std::string new_nick = client.getNickname();
-		std::string old_prefix = old_nick + "!" + client.getUsername() + "@" + client.getHostIP();
-		std::string new_prefix = new_nick + "!" + client.getUsername() + "@" + client.getHostIP();
+		std::string old_prefix = old_nick + "!" + client.getUsername() + "@" + client.getHost();
+		std::string new_prefix = new_nick + "!" + client.getUsername() + "@" + client.getHost();
 		client.setPrefix(new_prefix);
 		std::string nick_message = ":" + old_prefix + " NICK :" + new_nick + "\r\n";
 		// std::string nick_message = " NICK :" + new_nick + "\r\n";
@@ -83,7 +83,10 @@ int		Server::userCommand(Msg msg, Client &client)
 	if (client.getPasswordChecked())
 	{
 		client.setUsername(msg.parameters[0]);
-		std::string message_001 = ":ircserv 001 " + client.getNickname() + " :Welcome to the IRC network " + client.getNickname() + "!" + client.getUsername() + "@" + client.getHostIP() + "\r\n";
+		client.setHostname(msg.parameters[1]);
+		client.setHost(msg.parameters[2]);
+		client.setRealname(msg.trailing_msg);
+		std::string message_001 = ":ircserv 001 " + client.getNickname() + " :Welcome to the IRC network " + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + "\r\n";
 		send(client.getSocket(), message_001.c_str(), message_001.size(), 0);
 		std::string message_002 = ":ircserv 002 " + client.getNickname() + " :Your host is ircserv, running version 1.0\r\n";
 		send(client.getSocket(), message_002.c_str(), message_002.size(), 0);
@@ -102,7 +105,7 @@ int		Server::userCommand(Msg msg, Client &client)
 			send(client.getSocket(), nick_message.c_str(), nick_message.size(), 0);
 		}
 		// set client prefix
-		std::string setPrefix = client.getNickname() + "!" + client.getUsername() + "@" + client.getHostIP();
+		std::string setPrefix = client.getNickname() + "!" + client.getUsername() + "@" + client.getHost();
 		client.setPrefix(setPrefix);
 		client.setWelcomeSent(true);
 		return (0);

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -29,7 +29,7 @@ void Server::joinChannelMessage(std::string channelName, Client &client)
 {
 	int i = getChannelIndex(channelName, this->_channel_names);
 
-	std::string message = ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHostIP() + " JOIN " + channelName + "\r\n";
+	std::string message = ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + channelName + "\r\n";
 	broadcastToChannel(this->_channel_names[i], message, client, 0);
 
 	std::string topic = this->_channel_names[i].getChannelTopic();

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -65,7 +65,8 @@ void		Server::joinCommand(Msg msg, Client &client)
 		createChannel(msg, client);
 	else //Join channel
 	{
-		channelJoinChecks(this ->_channel_names[i], msg, client);
+		if (channelJoinChecks(this ->_channel_names[i], msg, client))
+			return ;
 		addChannelUser(this->_channel_names[i], client, false);
 	}
 	joinChannelMessage(msg.parameters[0], client);

--- a/src/makeSelectAndRunCommand.cpp
+++ b/src/makeSelectAndRunCommand.cpp
@@ -52,6 +52,10 @@ int		Server::commandSelector(Msg msg, Client &client)
 	{
 		joinCommand(msg, client);
 	}
+	else if (msg.command == "WHO")
+	{
+		whoCommand(msg, client);
+	}
 	else if (msg.command[0] == ':')
 	{
 		std::string response = "Please no Prefixes in Commands. Server No like.\r\n";

--- a/src/who.cpp
+++ b/src/who.cpp
@@ -1,0 +1,24 @@
+#include "Server.hpp"
+#include "Msg.hpp"
+
+void	Server::whoCommand(Msg msg, Client &client)
+{
+    int i = getChannelIndex(msg.parameters[0], _channel_names);
+    const std::vector<User>& channel_users = _channel_names[i].getChannelUsers();
+
+    for (size_t i = 0; i < channel_users.size(); ++i) 
+	{
+        for (auto it : _clients)
+        {
+            if (it.getNickname() == channel_users[i].nickname)
+            {
+                std::string message = ":ircserver 352 " + client.getNickname() + " " + msg.parameters[0] + " " + it.getUsername() + " " + it.getHostname() + " ircserver " + it.getNickname() + " :" + it.getRealname() + "\r\n";
+                send(client.getSocket(), message.c_str(), message.size(), 0);
+            }
+        }
+    }
+    std::string message = ":ircserver 315 " + client.getNickname() + " " + msg.parameters[0] + " :End of /WHO list\r\n";
+    send(client.getSocket(), message.c_str(), message.size(), 0);
+}
+
+// username hostname server nickname flags hopCount realName


### PR DESCRIPTION
- Client no longer sends join message if join checks fail.
- When a user parted from a channel this (17:11 -!- Irssi: critical nicklist_set_host: assertion 'host != NULL' failed) printed in the home window when the user was an operator. I have fixed this by adding a handler for the WHO message.
- Added some variables to the client that were required for WHO.